### PR TITLE
Update GeoIP2.php to not crash on multiple addresses 

### DIFF
--- a/src/Provider/GeoIP2/GeoIP2.php
+++ b/src/Provider/GeoIP2/GeoIP2.php
@@ -47,9 +47,10 @@ final class GeoIP2 extends AbstractProvider implements Provider
     public function geocodeQuery(GeocodeQuery $query): Collection
     {
         $address = $query->getText();
+        $address = explode(',', $address)[0]; 
         $locale = $query->getLocale() ?: 'en'; // Default to English
         if (!filter_var($address, FILTER_VALIDATE_IP)) {
-            throw new UnsupportedOperation('The GeoIP2 provider does not support street addresses, only IP addresses.');
+            throw new UnsupportedOperation(sprintf('"%s" must be called with an IP addresses. Got "%s" instead.', __METHOD__, $address));
         }
 
         if ('127.0.0.1' === $address) {
@@ -110,6 +111,7 @@ final class GeoIP2 extends AbstractProvider implements Provider
      */
     private function executeQuery(string $address): string
     {
+        $address = explode(',', $address)[0]; 
         $uri = sprintf('file://geoip?%s', $address);
 
         try {


### PR DESCRIPTION
Better error message to share what was in $address, instead of just assuming it was a street address.

if using a proxy like CloudFlare, which may return multiple IP addresses like X-forwarded-for and X-real-ip and the IP address of the Cloudflare proxy... then the $address may be a comma delimited list of addresses and both executeQuery AND geocodeQuery will fail.  Suggest just grabbing the first address and moving on .... something like  $address = explode(',', $address)[0];